### PR TITLE
convert histogram metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,9 +949,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4929e1f84c5e54c3ec6141cd5d8b5a5c055f031f80cf78f2072920173cb4d880"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1485,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags",
 ]
@@ -1970,14 +1982,14 @@ dependencies = [
 
 [[package]]
 name = "sozu-client"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c7967edbe9836d3eed9dd44d3804c5ace8798d6aca2f27926f3e8a00bc5fdc"
+checksum = "85fac7a514b946392e349307a71d45df69bbbeb5964ec232b6549f1b2cdba889"
 dependencies = [
  "async-trait",
  "bb8",
  "config",
- "mio",
+ "mio 1.0.0",
  "serde_json",
  "sozu-command-lib",
  "tempdir",
@@ -1988,15 +2000,15 @@ dependencies = [
 
 [[package]]
 name = "sozu-command-lib"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7c4c859df42f9504d8a79630dfa847115903b65425f1b30847cd6979aa2d17"
+checksum = "1f587a5cf85a7b8acaed005bca6502b7bd241a3e931d2cfb462327d540086004"
 dependencies = [
  "hex",
  "libc",
  "log",
  "memchr",
- "mio",
+ "mio 1.0.0",
  "nix",
  "nom",
  "pool",
@@ -2138,18 +2150,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2223,14 +2235,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2263,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2284,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.15"
+version = "0.22.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
+checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ serde = { version = "^1.0.195", features = ["derive"] }
 serde_json = "^1.0.111"
 sentry = { version = "^0.34.0", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls"] }
 sentry-tracing = "^0.34.0"
-sozu-client = "^0.4.0"
-sozu-command-lib = "^1.0.0"
+sozu-client = "^0.4.1"
+sozu-command-lib = "^1.0.3"
 thiserror = "^1.0.56"
 tokio = { version = "^1.35.1", features = ["macros", "rt", "signal"] }
 tracing = "^0.1.40"

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,9 +1,6 @@
 # Socket address on which to listen
 listening-address = "0.0.0.0:3000"
 
-# aggregate backend metrics by cluster id
-aggregate-backend-metrics = true
-
 [sozu]
 # Path to Sōzu's configuration file
 configuration = "path/to/sozu/config.toml"

--- a/src/svc/config.rs
+++ b/src/svc/config.rs
@@ -42,8 +42,6 @@ pub struct Sozu {
 pub struct ConnectorConfiguration {
     #[serde(rename = "listening-address")]
     pub listening_address: SocketAddr,
-    #[serde(rename = "aggregate-backend-metrics")]
-    pub aggregate_backend_metrics: bool,
     #[serde(rename = "sozu")]
     pub sozu: Sozu,
     #[serde(rename = "sentry")]

--- a/src/svc/http/server/handler.rs
+++ b/src/svc/http/server/handler.rs
@@ -97,10 +97,7 @@ pub async fn telemetry(State(state): State<server::State>, _req: Request<Body>) 
                     content_type: Some(ContentType::Metrics(aggregated_metrics)),
                 }),
             ..
-        }) => convert_metrics_to_prometheus(
-            aggregated_metrics,
-            state.config.aggregate_backend_metrics,
-        ),
+        }) => convert_metrics_to_prometheus(aggregated_metrics),
         Ok(response) => {
             let headers = res.headers_mut();
             let message = serde_json::json!({


### PR DESCRIPTION
1. Sōzu now aggregates metrics accross workers, no need to do it anymore
2. Sōzu now produces prometheus-compatible histograms, we can convert them to metric lines.